### PR TITLE
Center the floating menu and move the avatar menu into it (if enabled)

### DIFF
--- a/Impressia.xcodeproj/project.pbxproj
+++ b/Impressia.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F24D9422D53DECF0001AE15 /* AccountAvatarMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24D9412D53DECB0001AE15 /* AccountAvatarMenu.swift */; };
 		F802884F297AEED5000BDD51 /* DatabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802884E297AEED5000BDD51 /* DatabaseError.swift */; };
 		F805DCF129DBEF83006A1FD9 /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F805DCF029DBEF83006A1FD9 /* ReportView.swift */; };
 		F808641429756666009F035C /* NotificationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F808641329756666009F035C /* NotificationRowView.swift */; };
@@ -211,6 +212,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F24D9412D53DECB0001AE15 /* AccountAvatarMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAvatarMenu.swift; sourceTree = "<group>"; };
 		F802884E297AEED5000BDD51 /* DatabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseError.swift; sourceTree = "<group>"; };
 		F805DCF029DBEF83006A1FD9 /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		F808641329756666009F035C /* NotificationRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRowView.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 				F88C246D295C37B80006098B /* MainView.swift */,
 				F88ABD9329687CA4004EF61E /* ComposeView.swift */,
 				F8D0E5212AE2A2630061C561 /* HomeTimelineView.swift */,
+				1F24D9412D53DECB0001AE15 /* AccountAvatarMenu.swift */,
 				F88AB05729B36B8200345EDE /* AccountsPhotoView.swift */,
 				F88E4D47297E90CD0057491A /* TrendStatusesView.swift */,
 				F883401F29B62AE900C3E096 /* SearchView.swift */,
@@ -1091,6 +1094,7 @@
 				F8B0886029943498002AB40A /* OtherSectionView.swift in Sources */,
 				F808641429756666009F035C /* NotificationRowView.swift in Sources */,
 				F8624D3D29F2D3AC00204986 /* SelectedMenuItemDetails.swift in Sources */,
+				1F24D9422D53DECF0001AE15 /* AccountAvatarMenu.swift in Sources */,
 				F8210DCF2966B600001D9973 /* ImageRowAsync.swift in Sources */,
 				F86A4305299AA12800DF7645 /* PurchaseError.swift in Sources */,
 				F8B05ACE29B48E2F00857221 /* MediaSettingsView.swift in Sources */,

--- a/Impressia/ViewModifiers/NavigationMenuButtons.swift
+++ b/Impressia/ViewModifiers/NavigationMenuButtons.swift
@@ -77,7 +77,7 @@ private struct NavigationMenuButtons: ViewModifier {
     private func menuContainerView() -> some View {
         if self.menuPosition == .bottomRight {
             HStack(alignment: .center) {
-                AccountAvatarMenu(viewMode: $viewMode)
+                AccountAvatarMenu(menuPosition: $menuPosition, viewMode: $viewMode)
 
                 HStack {
                     self.contextMenuView()
@@ -112,7 +112,7 @@ private struct NavigationMenuButtons: ViewModifier {
                 .background(.ultraThinMaterial)
                 .clipShape(Capsule())
 
-                AccountAvatarMenu(viewMode: $viewMode)
+                AccountAvatarMenu(menuPosition: $menuPosition, viewMode: $viewMode)
             }
             .popoverTip(menuCustomizableTip, arrowEdge: .bottom)
         }

--- a/Impressia/ViewModifiers/NavigationMenuButtons.swift
+++ b/Impressia/ViewModifiers/NavigationMenuButtons.swift
@@ -14,8 +14,11 @@ import WidgetsKit
 @MainActor
 extension View {
     func navigationMenuButtons(menuPosition: Binding<MenuPosition>,
+                               viewMode: Binding<MainView.ViewMode>,
                                onViewModeIconTap: @escaping (MainView.ViewMode) -> Void) -> some View {
-        modifier(NavigationMenuButtons(menuPosition: menuPosition, onViewModeIconTap: onViewModeIconTap))
+        modifier(NavigationMenuButtons(menuPosition: menuPosition,
+                                       viewMode: viewMode,
+                                       onViewModeIconTap: onViewModeIconTap))
     }
 }
 
@@ -38,10 +41,12 @@ private struct NavigationMenuButtons: ViewModifier {
     @State private var hiddenMenuItems: [MainView.ViewMode] = []
 
     @Binding var menuPosition: MenuPosition
+    @Binding var viewMode: MainView.ViewMode
 
-    init(menuPosition: Binding<MenuPosition>, onViewModeIconTap: @escaping (MainView.ViewMode) -> Void) {
+    init(menuPosition: Binding<MenuPosition>, viewMode: Binding<MainView.ViewMode>, onViewModeIconTap: @escaping (MainView.ViewMode) -> Void) {
         self.onViewModeIconTap = onViewModeIconTap
         self._menuPosition = menuPosition
+        self._viewMode = viewMode
     }
 
     func body(content: Content) -> some View {
@@ -53,22 +58,12 @@ private struct NavigationMenuButtons: ViewModifier {
 
                 VStack(alignment: .trailing) {
                     Spacer()
+
                     HStack(alignment: .center) {
-                        if self.menuPosition == .bottomRight {
-                            Spacer()
-
-                            self.menuContainerView()
-                                .padding(.trailing, 24)
-                                .padding(.bottom, 10)
-                        }
-
-                        if self.menuPosition == .bottomLeft {
-                            self.menuContainerView()
-                                .padding(.leading, 24)
-                                .padding(.bottom, 10)
-
-                            Spacer()
-                        }
+                        Spacer()
+                        self.menuContainerView()
+                            .padding(.bottom, 10)
+                        Spacer()
                     }
                 }
                 .onAppear {
@@ -82,6 +77,8 @@ private struct NavigationMenuButtons: ViewModifier {
     private func menuContainerView() -> some View {
         if self.menuPosition == .bottomRight {
             HStack(alignment: .center) {
+                AccountAvatarMenu(viewMode: $viewMode)
+
                 HStack {
                     self.contextMenuView()
                     self.customMenuItemsView()
@@ -114,6 +111,8 @@ private struct NavigationMenuButtons: ViewModifier {
                 .padding(.horizontal, 8)
                 .background(.ultraThinMaterial)
                 .clipShape(Capsule())
+
+                AccountAvatarMenu(viewMode: $viewMode)
             }
             .popoverTip(menuCustomizableTip, arrowEdge: .bottom)
         }

--- a/Impressia/Views/AccountAvatarMenu.swift
+++ b/Impressia/Views/AccountAvatarMenu.swift
@@ -1,0 +1,139 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import ClientKit
+import EnvironmentKit
+import ServicesKit
+import SwiftData
+import SwiftUI
+
+@MainActor
+struct AccountAvatarMenu: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @Environment(ApplicationState.self) var applicationState
+    @Environment(Client.self) var client
+    @Environment(RouterPath.self) var routerPath
+
+    @Query(sort: \AccountData.acct, order: .forward) var dbAccounts: [AccountData]
+
+    @Binding var viewMode: MainView.ViewMode
+
+    var body: some View {
+        Menu {
+            ForEach(self.dbAccounts) { account in
+                Button {
+                    self.switchAccounts(account)
+                } label: {
+                    HStack {
+                        Text(account.displayName ?? account.acct)
+                        self.getAvatarImage(avatarUrl: account.avatar, avatarData: account.avatarData)
+                    }
+                }
+                .disabled(account.id == self.applicationState.account?.id)
+            }
+
+            Divider()
+
+            Button {
+                HapticService.shared.fireHaptic(of: .buttonPress)
+                self.routerPath.presentedSheet = .settings
+            } label: {
+                Label("mainview.menu.settings", systemImage: "gear")
+            }
+        } label: {
+            self.getAvatarImage(avatarUrl: self.applicationState.account?.avatar,
+                                avatarData: self.applicationState.account?.avatarData)
+        }
+    }
+
+    @ViewBuilder
+    private func getAvatarImage(avatarUrl: URL?, avatarData: Data?) -> some View {
+        if let avatarData,
+           let uiImage = UIImage(data: avatarData)?.roundedAvatar(avatarShape: self.applicationState.avatarShape) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .frame(width: 32.0, height: 32.0)
+                .clipShape(self.applicationState.avatarShape.shape())
+        } else if let avatarUrl {
+            AsyncImage(url: avatarUrl)
+                .frame(width: 32.0, height: 32.0)
+                .clipShape(self.applicationState.avatarShape.shape())
+        } else {
+            Image(systemName: "person")
+                .resizable()
+                .frame(width: 16, height: 16)
+                .foregroundColor(.white)
+                .padding(8)
+                .background(Color.customGrayColor)
+                .clipShape(AvatarShape.circle.shape())
+                .background(
+                    AvatarShape.circle.shape()
+                )
+        }
+    }
+
+    private func switchAccounts(_ account: AccountData) {
+        HapticService.shared.fireHaptic(of: .buttonPress)
+
+        if viewMode == .search {
+            self.hideKeyboard()
+            self.asyncAfter(0.3) {
+                self.tryToSwitch(account)
+            }
+        } else {
+            self.tryToSwitch(account)
+        }
+    }
+
+    private func tryToSwitch(_ account: AccountData) {
+        Task {
+            // Verify access token correctness.
+            let authorizationSession = AuthorizationSession()
+            let accountModel = account.toAccountModel()
+
+            await AuthorizationService.shared.verifyAccount(session: authorizationSession,
+                                                            accountModel: accountModel,
+                                                            modelContext: modelContext) { signedInAccountModel in
+                guard let signedInAccountModel else {
+                    ToastrService.shared.showError(title: "", subtitle: NSLocalizedString("mainview.error.switchAccounts", comment: "Cannot switch accounts."))
+                    return
+                }
+
+                Task { @MainActor in
+                    let instance = try? await self.client.instances.instance(url: signedInAccountModel.serverUrl)
+
+                    // Refresh client state.
+                    self.client.setAccount(account: signedInAccountModel)
+
+                    // Refresh application state.
+                    self.applicationState.changeApplicationState(accountModel: signedInAccountModel,
+                                                                 instance: instance,
+                                                                 lastSeenStatusId: signedInAccountModel.lastSeenStatusId,
+                                                                 lastSeenNotificationId: signedInAccountModel.lastSeenNotificationId)
+
+                    // Set account as default (application will open this account after restart).
+                    ApplicationSettingsHandler.shared.set(accountId: signedInAccountModel.id, modelContext: modelContext)
+
+                    // Refresh new photos and notifications.
+                    _ = await (self.calculateNewPhotosInBackground(), self.calculateNewNotificationsInBackground())
+                }
+            }
+        }
+    }
+
+    private func calculateNewPhotosInBackground() async {
+        self.applicationState.amountOfNewStatuses = await HomeTimelineService.shared.amountOfNewStatuses(
+            includeReblogs: self.applicationState.showReboostedStatuses,
+            hideStatusesWithoutAlt: self.applicationState.hideStatusesWithoutAlt,
+            modelContext: modelContext
+        )
+    }
+
+    private func calculateNewNotificationsInBackground() async {
+        self.applicationState.amountOfNewNotifications = await NotificationsService.shared.amountOfNewNotifications(modelContext: modelContext)
+    }
+}

--- a/Impressia/Views/AccountAvatarMenu.swift
+++ b/Impressia/Views/AccountAvatarMenu.swift
@@ -20,6 +20,7 @@ struct AccountAvatarMenu: View {
 
     @Query(sort: \AccountData.acct, order: .forward) var dbAccounts: [AccountData]
 
+    @Binding var menuPosition: MenuPosition
     @Binding var viewMode: MainView.ViewMode
 
     var body: some View {
@@ -45,8 +46,21 @@ struct AccountAvatarMenu: View {
                 Label("mainview.menu.settings", systemImage: "gear")
             }
         } label: {
+            self.avatarButton()
+        }
+    }
+
+    @ViewBuilder
+    private func avatarButton() -> some View {
+        if menuPosition == .top {
             self.getAvatarImage(avatarUrl: self.applicationState.account?.avatar,
                                 avatarData: self.applicationState.account?.avatarData)
+        } else {
+            self.getAvatarImage(avatarUrl: self.applicationState.account?.avatar,
+                                avatarData: self.applicationState.account?.avatarData)
+                .padding(9) // (menu height - avatar size) / 2
+                .background(.ultraThinMaterial)
+                .clipShape(.circle)
         }
     }
 

--- a/Impressia/Views/MainView.swift
+++ b/Impressia/Views/MainView.swift
@@ -6,19 +6,14 @@
 
 import SwiftUI
 import UIKit
-import SwiftData
 import PixelfedKit
-import ClientKit
 import ServicesKit
 import EnvironmentKit
 import WidgetsKit
 
 @MainActor
 struct MainView: View {
-    @Environment(\.modelContext) private var modelContext
-
     @Environment(ApplicationState.self) var applicationState
-    @Environment(Client.self) var client
     @Environment(RouterPath.self) var routerPath
     @Environment(TipsStore.self) var tipsStore
 
@@ -30,8 +25,6 @@ struct MainView: View {
     }
 
     private let mainNavigationTip = MainNavigationTip()
-    
-    @Query(sort: \AccountData.acct, order: .forward) var dbAccounts: [AccountData]
 
     public enum ViewMode: Int, Identifiable {
         case home = 1
@@ -204,31 +197,7 @@ struct MainView: View {
     @ToolbarContentBuilder
     private func getLeadingToolbar() -> some ToolbarContent {
         ToolbarItem(placement: .navigationBarLeading) {
-            Menu {
-                ForEach(self.dbAccounts) { account in
-                    Button {
-                        self.switchAccounts(account)
-                    } label: {
-                        HStack {
-                            Text(account.displayName ?? account.acct)
-                            self.getAvatarImage(avatarUrl: account.avatar, avatarData: account.avatarData)
-                        }
-                    }
-                    .disabled(account.id == self.applicationState.account?.id)
-                }
-
-                Divider()
-
-                Button {
-                    HapticService.shared.fireHaptic(of: .buttonPress)
-                    self.routerPath.presentedSheet = .settings
-                } label: {
-                    Label("mainview.menu.settings", systemImage: "gear")
-                }
-            } label: {
-                self.getAvatarImage(avatarUrl: self.applicationState.account?.avatar,
-                                    avatarData: self.applicationState.account?.avatarData)
-            }
+            AccountAvatarMenu(viewMode: $viewMode)
         }
     }
 
@@ -248,32 +217,6 @@ struct MainView: View {
         }
     }
 
-    @ViewBuilder
-    private func getAvatarImage(avatarUrl: URL?, avatarData: Data?) -> some View {
-        if let avatarData,
-           let uiImage = UIImage(data: avatarData)?.roundedAvatar(avatarShape: self.applicationState.avatarShape) {
-            Image(uiImage: uiImage)
-                .resizable()
-                .frame(width: 32.0, height: 32.0)
-                .clipShape(self.applicationState.avatarShape.shape())
-        } else if let avatarUrl {
-            AsyncImage(url: avatarUrl)
-                .frame(width: 32.0, height: 32.0)
-                .clipShape(self.applicationState.avatarShape.shape())
-        } else {
-            Image(systemName: "person")
-                .resizable()
-                .frame(width: 16, height: 16)
-                .foregroundColor(.white)
-                .padding(8)
-                .background(Color.customGrayColor)
-                .clipShape(AvatarShape.circle.shape())
-                .background(
-                    AvatarShape.circle.shape()
-                )
-        }
-    }
-
     private func switchView(to newViewMode: ViewMode) {
         HapticService.shared.fireHaptic(of: .tabSelection)
 
@@ -285,66 +228,5 @@ struct MainView: View {
         } else {
             self.viewMode = newViewMode
         }
-    }
-
-    private func switchAccounts(_ account: AccountData) {
-        HapticService.shared.fireHaptic(of: .buttonPress)
-
-        if viewMode == .search {
-            self.hideKeyboard()
-            self.asyncAfter(0.3) {
-                self.tryToSwitch(account)
-            }
-        } else {
-            self.tryToSwitch(account)
-        }
-    }
-
-    private func tryToSwitch(_ account: AccountData) {
-        Task {
-            // Verify access token correctness.
-            let authorizationSession = AuthorizationSession()
-            let accountModel = account.toAccountModel()
-
-            await AuthorizationService.shared.verifyAccount(session: authorizationSession,
-                                                            accountModel: accountModel,
-                                                            modelContext: modelContext) { signedInAccountModel in
-                guard let signedInAccountModel else {
-                    ToastrService.shared.showError(title: "", subtitle: NSLocalizedString("mainview.error.switchAccounts", comment: "Cannot switch accounts."))
-                    return
-                }
-
-                Task { @MainActor in
-                    let instance = try? await self.client.instances.instance(url: signedInAccountModel.serverUrl)
-
-                    // Refresh client state.
-                    self.client.setAccount(account: signedInAccountModel)
-
-                    // Refresh application state.
-                    self.applicationState.changeApplicationState(accountModel: signedInAccountModel,
-                                                                 instance: instance,
-                                                                 lastSeenStatusId: signedInAccountModel.lastSeenStatusId,
-                                                                 lastSeenNotificationId: signedInAccountModel.lastSeenNotificationId)
-
-                    // Set account as default (application will open this account after restart).
-                    ApplicationSettingsHandler.shared.set(accountId: signedInAccountModel.id, modelContext: modelContext)
-                    
-                    // Refresh new photos and notifications.
-                    _ = await (self.calculateNewPhotosInBackground(), self.calculateNewNotificationsInBackground())
-                }
-            }
-        }
-    }
-    
-    private func calculateNewPhotosInBackground() async {
-        self.applicationState.amountOfNewStatuses = await HomeTimelineService.shared.amountOfNewStatuses(
-            includeReblogs: self.applicationState.showReboostedStatuses,
-            hideStatusesWithoutAlt: self.applicationState.hideStatusesWithoutAlt,
-            modelContext: modelContext
-        )
-    }
-    
-    private func calculateNewNotificationsInBackground() async {
-        self.applicationState.amountOfNewNotifications = await NotificationsService.shared.amountOfNewNotifications(modelContext: modelContext)
     }
 }

--- a/Impressia/Views/MainView.swift
+++ b/Impressia/Views/MainView.swift
@@ -104,7 +104,7 @@ struct MainView: View {
 
         NavigationStack(path: $routerPath.path) {
             self.getMainView()
-                .navigationMenuButtons(menuPosition: $applicationState.menuPosition) { viewMode in
+                .navigationMenuButtons(menuPosition: $applicationState.menuPosition, viewMode: $viewMode) { viewMode in
                     self.switchView(to: viewMode)
                 }
                 .navigationTitle(navBarTitle)
@@ -196,8 +196,10 @@ struct MainView: View {
 
     @ToolbarContentBuilder
     private func getLeadingToolbar() -> some ToolbarContent {
-        ToolbarItem(placement: .navigationBarLeading) {
-            AccountAvatarMenu(viewMode: $viewMode)
+        if applicationState.menuPosition == .top {
+            ToolbarItem(placement: .navigationBarLeading) {
+                AccountAvatarMenu(viewMode: $viewMode)
+            }
         }
     }
 

--- a/Impressia/Views/MainView.swift
+++ b/Impressia/Views/MainView.swift
@@ -197,8 +197,10 @@ struct MainView: View {
     @ToolbarContentBuilder
     private func getLeadingToolbar() -> some ToolbarContent {
         if applicationState.menuPosition == .top {
+            @Bindable var applicationState = applicationState
+
             ToolbarItem(placement: .navigationBarLeading) {
-                AccountAvatarMenu(viewMode: $viewMode)
+                AccountAvatarMenu(menuPosition: $applicationState.menuPosition, viewMode: $viewMode)
             }
         }
     }


### PR DESCRIPTION
This is coming out of the blue, admittedly. I had to see if I can actually pull it off before proposing the change. Turns out: I can. :)

I like Impressia's option to have the menu bar floating at the bottom of the screen. Even on an iPhone mini and with my big hands, the top of the screen is rather inconvenient to reach. However, I found the menu to look quite unbalanced with just the "new post" button on one side. Especially since it appears otherwise centered on my iPhone mini screen - instead of aligned to the left or right edge as it is on bigger phones.

I took up on the centered impression for this proposal. (This only affects the `bottom-left` and `bottom-right` menu options, the `top` option remains visually the same.) To balance the menu, I moved the avatar menu to the other side of the floating `viewMode` menu so that it looks symmetrical. The avatar button needs to be a little larger in the floating menu. I personally prefer it having padding of `ultraThinMaterial` instead of increasing the avatar size to the menu height.

Additionally, I centered the floating menu horizontally on-screen, instead of aligning to the left or right. Alas this is a bit at odds with the naming of the menu options now. The left/right options still affect the order of elements in the menu, so they still make sense imho.

One more technical thing: `AccountAvatarMenu` now depends on `viewMode` only because `switchAccounts()` needs it. I wondered if that can be solved more elegantly with a callback that dismisses the keyboard if necessary. Might also make things even more complicated in the end...

Please take a look and let me know what you think about this. I'm open to discussing adjustments! :)

## Before
![before](https://github.com/user-attachments/assets/a22671c3-7688-49c8-b1b1-0016bf8cdc5c)

## After
![after](https://github.com/user-attachments/assets/50cee3b4-6749-4c9b-b75d-e2b140535868)
